### PR TITLE
Issue 5: re-emit oidc-client events so clients can add custom hooks

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -9,7 +9,6 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "oidc-client": "^1.10.1",
     "vue-oidc-client": "^0.4.1"
   },
   "devDependencies": {

--- a/sample/src/main.js
+++ b/sample/src/main.js
@@ -37,9 +37,9 @@ mainAuth.$on('userSignedOut', function() {
   console.log('user signed out');
 });
 
-mainAuth.$on('userSessionChanged', function(user) {
+mainAuth.$on('userSessionChanged', function() {
   // eslint-disable-next-line no-console
-  console.log('user session changed', user);
+  console.log('user session changed');
 });
 
 mainAuth.startup().then(ok => {

--- a/sample/src/main.js
+++ b/sample/src/main.js
@@ -7,6 +7,41 @@ import router from './router';
 
 Vue.config.productionTip = false;
 
+mainAuth.$on('accessTokenExpiring', function() {
+  // eslint-disable-next-line no-console
+  console.log('access token expiring');
+});
+
+mainAuth.$on('accessTokenExpired', function() {
+  // eslint-disable-next-line no-console
+  console.log('access token expired');
+});
+
+mainAuth.$on('silentRenewError', function(err) {
+  // eslint-disable-next-line no-console
+  console.error('silent renew error', err);
+});
+
+mainAuth.$on('userLoaded', function(user) {
+  // eslint-disable-next-line no-console
+  console.log('user loaded', user);
+});
+
+mainAuth.$on('userUnloaded', function() {
+  // eslint-disable-next-line no-console
+  console.log('user unloaded');
+});
+
+mainAuth.$on('userSignedOut', function() {
+  // eslint-disable-next-line no-console
+  console.log('user signed out');
+});
+
+mainAuth.$on('userSessionChanged', function(user) {
+  // eslint-disable-next-line no-console
+  console.log('user session changed', user);
+});
+
 mainAuth.startup().then(ok => {
   if (ok) {
     new Vue({

--- a/src/VueOidcAuth.js
+++ b/src/VueOidcAuth.js
@@ -146,8 +146,8 @@ export function createOidcAuth(
     signInIfNecessary()
   })
 
-  mgr.events.addUserSessionChanged(user => {
-    Log.debug(`${authName} auth user session changed:`, user)
+  mgr.events.addUserSessionChanged(() => {
+    Log.debug(`${authName} auth user session changed`)
     auth.$emit('userSessionChanged')
   })
 

--- a/src/VueOidcAuth.js
+++ b/src/VueOidcAuth.js
@@ -86,6 +86,7 @@ export function createOidcAuth(
   ///////////////////////////////
   mgr.events.addAccessTokenExpiring(() => {
     Log.debug(`${authName} auth token expiring`)
+    auth.$emit('accessTokenExpiring')
   })
 
   mgr.events.addAccessTokenExpired(() => {
@@ -93,6 +94,7 @@ export function createOidcAuth(
       `${authName} auth token expired, user is authenticated=${auth.isAuthenticated}`
     )
     auth.user = null
+    auth.$emit('accessTokenExpired')
     signInIfNecessary()
     // if (auth.isAuthenticated) {
     //   mgr
@@ -111,6 +113,7 @@ export function createOidcAuth(
 
   mgr.events.addSilentRenewError(e => {
     Log.debug(`${authName} auth silent renew error ${e}`)
+    auth.$emit('silentRenewError', e)
     // TODO: need to restart renew manually?
     if (auth.isAuthenticated) {
       setTimeout(() => {
@@ -124,10 +127,12 @@ export function createOidcAuth(
 
   mgr.events.addUserLoaded(user => {
     auth.user = user
+    auth.$emit('userLoaded', user)
   })
 
   mgr.events.addUserUnloaded(() => {
     auth.user = undefined
+    auth.$emit('userUnloaded')
 
     // redirect if on protected route (best method here?)
     Log.debug(`${authName} auth user unloaded`)
@@ -137,11 +142,13 @@ export function createOidcAuth(
   mgr.events.addUserSignedOut(() => {
     Log.debug(`${authName} auth user signed out`)
     auth.user = null
+    auth.$emit('userSignedOut')
     signInIfNecessary()
   })
 
   mgr.events.addUserSessionChanged(user => {
     Log.debug(`${authName} auth user session changed:`, user)
+    auth.$emit('userSessionChanged')
   })
 
   function signInIfNecessary() {


### PR DESCRIPTION
This is to satisfy https://github.com/soukoku/vue-oidc-client/issues/5. Maybe it also satisfies https://github.com/soukoku/vue-oidc-client/issues/7 as it allows the client to write their own code to update the Vuex store.

To justify some of the other changes:
- remove `oidc-client` from sample: because it's already a dependency of `vue-oidc-client`
- remove `user` param to `addUserSessionChanged`: because the param is [not passed to us](https://github.com/IdentityModel/oidc-client-js/blob/1.10.1/src/UserManagerEvents.js#L88)

I thought about adding the [`userSignedIn`](https://github.com/IdentityModel/oidc-client-js/blob/1.10.1/src/UserManagerEvents.js#L15) event too, which looks like a [recent-ish addition](https://github.com/IdentityModel/oidc-client-js/blame/1.10.1/src/UserManagerEvents.js#L15). I decided against it because I'm not sure it adds any value.

Once this is merged, we can add the following to the wiki:

# Events
This library re-emits the [events](https://github.com/IdentityModel/oidc-client-js/wiki#events) from the underlying `oidc-client` library. You can hook them like this:
```js
mainOidc.$on('userLoaded', function(user) {
  console.log('user loaded', user)
  // you can interact with your Vuex store if you want to save some details
})

mainOidc.$on('userSignedOut', function() {
  console.log('user signed out');
})
```
The events available are:
  - `accessTokenExpiring`
  - `accessTokenExpired`
  - `silentRenewError`
  - `userLoaded`
  - `userUnloaded`
  - `userSignedOut`
  - `userSessionChanged`

See [the sample project](https://github.com/soukoku/vue-oidc-client/blob/master/sample/src/main.js) for more examples.