### PR TITLE
Expose user property as in vue 2 version

### DIFF
--- a/vue3/src/vue-oidc-client.ts
+++ b/vue3/src/vue-oidc-client.ts
@@ -180,6 +180,7 @@ export function createOidcAuth(
   const authObj = reactive({
     appUrl,
     authName,
+    user,
     isAuthenticated: computed(() => !!user.value && !user.value.expired),
     accessToken: computed(() =>
       !!user.value && !user.value.expired ? user.value.access_token : ''


### PR DESCRIPTION
We need acces to user property to get id_token in jwt format, accessToken is not always a jwt token.